### PR TITLE
fix: set userPin back to fix current implementation

### DIFF
--- a/packages/common/lib/types/StateManager.types.ts
+++ b/packages/common/lib/types/StateManager.types.ts
@@ -9,7 +9,8 @@ export interface CredentialOfferSession extends StateType {
   clientId?: string;
   credentialOffer: AssertedUniformCredentialOffer;
   credentialDataSupplierInput?: CredentialDataSupplierInput; // Optional storage that can help the credential Data Supplier. For instance to store credential input data during offer creation, if no additional data can be supplied later on
-  txCode?: string; // in here we only store the txCode, previously < V13 this was the userPin. We map the userPin onto this value
+  //txCode?: string; // in here we only store the txCode, previously < V13 this was the userPin. We map the userPin onto this value
+  userPin?: string; // in here we only store the userPin, previously < V13 this was the txCode. We map the txCode onto this value
   status: IssueStatus;
   error?: string;
   lastUpdatedAt: number;

--- a/packages/issuer/lib/tokens/index.ts
+++ b/packages/issuer/lib/tokens/index.ts
@@ -163,13 +163,13 @@ export const assertValidAccessTokenRequest = async (
         throw new TokenError(400, TokenErrorResponse.invalid_grant, `${PIN_VALIDATION_ERROR} ${txCodeOffer.length}`)
       }
     }
-    if (request.tx_code !== credentialOfferSession.txCode) {
+    if (request.tx_code !== credentialOfferSession.userPin) {
       throw new TokenError(400, TokenErrorResponse.invalid_grant, PIN_NOT_MATCH_ERROR)
     }
   } else if (request.user_pin) {
     if (!/[\\d]{1,8}/.test(request.user_pin)) {
       throw new TokenError(400, TokenErrorResponse.invalid_grant, `${PIN_VALIDATION_ERROR} 1-8`)
-    } else if (request.user_pin !== credentialOfferSession.txCode) {
+    } else if (request.user_pin !== credentialOfferSession.userPin) {
       throw new TokenError(400, TokenErrorResponse.invalid_grant, PIN_NOT_MATCH_ERROR)
     }
   }


### PR DESCRIPTION
Adds userPin back to the CredentialOfferSession

@nklomp this is just a fix to keep the current library working again. It would be better to replace userPin in all libraries. However this would break existing APIs