### PR TITLE
fix: remove bug for txCode

### DIFF
--- a/packages/client/lib/AccessTokenClient.ts
+++ b/packages/client/lib/AccessTokenClient.ts
@@ -104,7 +104,7 @@ export class AccessTokenClient {
 
     if (credentialOfferRequest?.supportedFlows.includes(AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW)) {
       this.assertAlphanumericPin(opts.pinMetadata, pin);
-      request.user_pin = pin;
+      request.tx_code = pin;
 
       request.grant_type = GrantTypes.PRE_AUTHORIZED_CODE;
       // we actually know it is there because of the isPreAuthCode call

--- a/packages/client/lib/AccessTokenClient.ts
+++ b/packages/client/lib/AccessTokenClient.ts
@@ -104,6 +104,7 @@ export class AccessTokenClient {
 
     if (credentialOfferRequest?.supportedFlows.includes(AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW)) {
       this.assertAlphanumericPin(opts.pinMetadata, pin);
+      request.user_pin = pin;
       request.tx_code = pin;
 
       request.grant_type = GrantTypes.PRE_AUTHORIZED_CODE;

--- a/packages/common/lib/types/Authorization.types.ts
+++ b/packages/common/lib/types/Authorization.types.ts
@@ -312,7 +312,7 @@ export interface AccessTokenRequest {
   'pre-authorized_code': string;
   redirect_uri?: string;
   scope?: string;
-  user_pin?: string; //pre draft 13
+  user_pin?: string; //this is for v11, not required in v13 anymore
   tx_code?: string; //draft 13
   [s: string]: unknown;
 }

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -192,7 +192,6 @@ export class VcIssuer<DIDDoc extends object> {
       status,
       notification_id: v4(),
       ...(userPin && { txCode: userPin }), // We used to use userPin according to older specs. We map these onto txCode now. If both are used, txCode in the end wins, even if they are different
-      ...(txCode && { txCode }),
       ...(opts.credentialDataSupplierInput && { credentialDataSupplierInput: opts.credentialDataSupplierInput }),
       credentialOffer,
     }

--- a/packages/issuer/lib/tokens/index.ts
+++ b/packages/issuer/lib/tokens/index.ts
@@ -102,12 +102,17 @@ export const assertValidAccessTokenRequest = async (
  invalid_request:
  the Authorization Server does not expect a PIN in the pre-authorized flow but the client provides a PIN
   */
-  if (!credentialOfferSession.credentialOffer.credential_offer?.grants?.[GrantTypes.PRE_AUTHORIZED_CODE]?.tx_code && request.tx_code) {
+  if (
+    !credentialOfferSession.credentialOffer.credential_offer?.grants?.[GrantTypes.PRE_AUTHORIZED_CODE]?.tx_code &&
+    request.tx_code &&
+    !request.user_pin
+  ) {
     // >= v13
     throw new TokenError(400, TokenErrorResponse.invalid_request, USER_PIN_NOT_REQUIRED_ERROR)
   } else if (
     !credentialOfferSession.credentialOffer.credential_offer?.grants?.[GrantTypes.PRE_AUTHORIZED_CODE]?.user_pin_required &&
-    request.user_pin
+    request.user_pin &&
+    !request.tx_code
   ) {
     // <= v12
     throw new TokenError(400, TokenErrorResponse.invalid_request, USER_PIN_NOT_REQUIRED_ERROR)


### PR DESCRIPTION
Fix for the bug in https://github.com/Sphereon-Opensource/OID4VC/commit/7d17d13d3485c5b6b55ef876eba8f09c9f7a788b

As explained in the comment there, the line below will overwrite the set value for the pin.
We do not need to store the value of `txCode` since this is already in the grant. So it's fine to remove this line without any side effects.