### PR TITLE
fix: jwk thumbprint digest

### DIFF
--- a/packages/common/lib/jwt/JwkThumbprint.ts
+++ b/packages/common/lib/jwt/JwkThumbprint.ts
@@ -44,7 +44,7 @@ export async function calculateJwkThumbprint(jwk: JWK, digestAlgorithm?: DigestA
     default:
       throw Error('"kty" (Key Type) Parameter missing or unsupported');
   }
-  return u8a.toString(defaultHasher(algorithm, JSON.stringify(components)), 'base64url');
+  return u8a.toString(defaultHasher(JSON.stringify(components), algorithm), 'base64url');
 }
 
 export async function getDigestAlgorithmFromJwkThumbprintUri(uri: string): Promise<DigestAlgorithm> {

--- a/packages/common/lib/jwt/__tests__/JwkThumbprint.spec.ts
+++ b/packages/common/lib/jwt/__tests__/JwkThumbprint.spec.ts
@@ -1,0 +1,16 @@
+import { calculateJwkThumbprint } from '../JwkThumbprint';
+
+describe('JwkThumbprint', () => {
+  test('correctly calculates jwk thumbprint', async () => {
+    // Based on https://www.rfc-editor.org/rfc/rfc7638.html#section-3.1
+    expect(
+      await calculateJwkThumbprint({
+        kty: 'RSA',
+        n: '0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw',
+        e: 'AQAB',
+        alg: 'RS256',
+        kid: '2011-04-29',
+      }),
+    ).toEqual('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs');
+  });
+});


### PR DESCRIPTION
Small error in the jwk thumbprint digest. Now also added a test based on the jwk thumbprint spec to ensure correctness