### PR TITLE
feat: added schemaValidation to CredentialRequestClient

### DIFF
--- a/packages/client/lib/CredentialRequestClientBuilder.ts
+++ b/packages/client/lib/CredentialRequestClientBuilder.ts
@@ -8,6 +8,7 @@ import {
   ExperimentalSubjectIssuance,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
+  SchemaValidation,
   UniformCredentialOfferRequest,
 } from '@sphereon/oid4vci-common';
 import { CredentialFormat } from '@sphereon/ssi-types';
@@ -170,6 +171,11 @@ export class CredentialRequestClientBuilder {
 
   public withCredentialType(credentialTypes: string | string[]): this {
     this._builder.withCredentialType(credentialTypes);
+    return this;
+  }
+
+  public withSchemaValidation(schemaValidation: SchemaValidation): this {
+    this._builder.withSchemaValidation(schemaValidation);
     return this;
   }
 

--- a/packages/client/lib/CredentialRequestClientBuilderV1_0_11.ts
+++ b/packages/client/lib/CredentialRequestClientBuilderV1_0_11.ts
@@ -11,6 +11,7 @@ import {
   getTypesFromOfferV1_0_11,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
+  SchemaValidation,
   UniformCredentialOfferRequest,
 } from '@sphereon/oid4vci-common';
 import { CredentialFormat } from '@sphereon/ssi-types';
@@ -24,6 +25,7 @@ export class CredentialRequestClientBuilderV1_0_11 {
   deferredCredentialAwait = false;
   deferredCredentialIntervalInMS = 5000;
   credentialTypes: string[] = [];
+  schemaValidation: SchemaValidation = SchemaValidation.WHEN_PRESENT;
   format?: CredentialFormat | OID4VCICredentialFormat;
   token?: string;
   version?: OpenId4VCIVersion;
@@ -126,6 +128,11 @@ export class CredentialRequestClientBuilderV1_0_11 {
 
   public withCredentialType(credentialTypes: string | string[]): this {
     this.credentialTypes = Array.isArray(credentialTypes) ? credentialTypes : [credentialTypes];
+    return this;
+  }
+
+  public withSchemaValidation(schemaValidation: SchemaValidation): this {
+    this.schemaValidation = schemaValidation;
     return this;
   }
 

--- a/packages/client/lib/CredentialRequestClientBuilderV1_0_13.ts
+++ b/packages/client/lib/CredentialRequestClientBuilderV1_0_13.ts
@@ -9,6 +9,7 @@ import {
   getIssuerFromCredentialOfferPayload,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
+  SchemaValidation,
   UniformCredentialOfferRequest,
 } from '@sphereon/oid4vci-common';
 import { CredentialFormat } from '@sphereon/ssi-types';
@@ -23,6 +24,7 @@ export class CredentialRequestClientBuilderV1_0_13 {
   deferredCredentialIntervalInMS = 5000;
   credentialIdentifier?: string;
   credentialTypes?: string[] = [];
+  schemaValidation: SchemaValidation = SchemaValidation.WHEN_PRESENT;
   format?: CredentialFormat | OID4VCICredentialFormat;
   token?: string;
   version?: OpenId4VCIVersion;
@@ -136,6 +138,11 @@ export class CredentialRequestClientBuilderV1_0_13 {
 
   public withCredentialType(credentialTypes: string | string[]): this {
     this.credentialTypes = Array.isArray(credentialTypes) ? credentialTypes : [credentialTypes];
+    return this;
+  }
+
+  public withSchemaValidation(schemaValidation: SchemaValidation): this {
+    this.schemaValidation = schemaValidation;
     return this;
   }
 

--- a/packages/client/lib/CredentialRequestClientV1_0_11.ts
+++ b/packages/client/lib/CredentialRequestClientV1_0_11.ts
@@ -13,6 +13,7 @@ import {
   OpenIDResponse,
   post,
   ProofOfPossession,
+  SchemaValidation,
   UniformCredentialRequest,
   URL_NOT_VALID,
 } from '@sphereon/oid4vci-common';
@@ -35,6 +36,7 @@ export interface CredentialRequestOptsV1_0_11 {
   format?: CredentialFormat | OID4VCICredentialFormat;
   proof: ProofOfPossession;
   token: string;
+  schemaValidation: SchemaValidation;
   version: OpenId4VCIVersion;
 }
 
@@ -54,6 +56,9 @@ export class CredentialRequestClientV1_0_11 {
     return this.credentialRequestOpts.credentialEndpoint;
   }
 
+  public getSchemaValidation(): SchemaValidation {
+    return this.credentialRequestOpts.schemaValidation;
+  }
   public getDeferredCredentialEndpoint(): string | undefined {
     return this.credentialRequestOpts.deferredCredentialEndpoint;
   }

--- a/packages/client/lib/__tests__/CredentialRequestClientV1_0_11.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClientV1_0_11.spec.ts
@@ -8,6 +8,7 @@ import {
   Jwt,
   OpenId4VCIVersion,
   ProofOfPossession,
+  SchemaValidation,
   URL_NOT_VALID,
   WellKnownEndpoints,
 } from '@sphereon/oid4vci-common';
@@ -90,6 +91,7 @@ describe('Credential Request Client ', () => {
     const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOffer({ credentialOffer: INITIATION_TEST_V1_0_08 })
       .withCredentialEndpoint(basePath + '/credential')
       .withFormat('ldp_vc')
+      .withSchemaValidation(SchemaValidation.NEVER)
       .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
       .build();
     const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
@@ -103,6 +105,7 @@ describe('Credential Request Client ', () => {
       .withClientId('sphereon:wallet')
       .withKid(kid)
       .build();
+    expect(credReqClient.getSchemaValidation()).toEqual(SchemaValidation.NEVER);
     expect(credReqClient.getCredentialEndpoint()).toEqual(basePath + '/credential');
     const credentialRequest = await credReqClient.createCredentialRequest({ proofInput: proof, version: OpenId4VCIVersion.VER_1_0_08 });
     expect(credentialRequest.proof?.jwt?.includes(partialJWT)).toBeTruthy();
@@ -120,6 +123,7 @@ describe('Credential Request Client ', () => {
     const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOffer({ credentialOffer: INITIATION_TEST_V1_0_08 })
       .withCredentialEndpoint(basePath + '/credential')
       .withFormat('ldp_vc')
+      .withSchemaValidation(SchemaValidation.ALWAYS)
       .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
       .build();
     const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
@@ -133,6 +137,7 @@ describe('Credential Request Client ', () => {
       .withClientId('sphereon:wallet')
       .withKid(kid_withoutDid)
       .build();
+    expect(credReqClient.getSchemaValidation()).toEqual(SchemaValidation.ALWAYS);
     expect(credReqClient.getCredentialEndpoint()).toEqual(basePath + '/credential');
     const credentialRequest = await credReqClient.createCredentialRequest({ proofInput: proof, version: OpenId4VCIVersion.VER_1_0_08 });
     expect(credentialRequest.proof?.jwt?.includes(partialJWT_withoutDid)).toBeTruthy();

--- a/packages/oid4vci-common/lib/types/Generic.types.ts
+++ b/packages/oid4vci-common/lib/types/Generic.types.ts
@@ -424,3 +424,9 @@ export type NotificationResult = {
 export interface NotificationErrorResponse {
   error: NotificationError | string;
 }
+
+export enum SchemaValidation {
+  ALWAYS = 'ALWAYS',
+  NEVER = 'NEVER',
+  WHEN_PRESENT = 'WHEN_PRESENT',
+}


### PR DESCRIPTION
added schemaValidation parameter to the CredentialRequestClient(Builder). This parameter is an enum with 3 values: `ALWAYS`, `NEVER`, ` WHEN_PRESENT`. When it's not configured in the builder (with available functions), we default to `WHEN_PRESENT`.