### PR TITLE
fix: offer creation improvements

### DIFF
--- a/packages/issuer/lib/__tests__/CredentialOfferUtils.spec.ts
+++ b/packages/issuer/lib/__tests__/CredentialOfferUtils.spec.ts
@@ -1,6 +1,6 @@
-import { CredentialOfferPayloadV1_0_11, CredentialOfferPayloadV1_0_13 } from '@sphereon/oid4vci-common'
+import { CredentialOfferPayloadV1_0_11, CredentialOfferPayloadV1_0_13, PRE_AUTH_CODE_LITERAL, PRE_AUTH_GRANT_LITERAL } from '@sphereon/oid4vci-common'
 
-import { createCredentialOfferURI, createCredentialOfferURIv1_0_11 } from '../index'
+import { createCredentialOfferObject, createCredentialOfferURI, createCredentialOfferURIv1_0_11 } from '../index'
 
 describe('CredentialOfferUtils should', () => {
   it('create a deeplink from credentialOffer object', () => {
@@ -14,10 +14,55 @@ describe('CredentialOfferUtils should', () => {
           issuer_state: 'eyJhbGciOiJSU0Et...FYUaBy',
         },
       },
-    } as CredentialOfferPayloadV1_0_13
-    expect(createCredentialOfferURI(undefined, { credentialOffer, state: 'eyJhbGciOiJSU0Et...FYUaBy' })).toEqual(
+    } satisfies CredentialOfferPayloadV1_0_13
+    expect(createCredentialOfferURI(undefined, { credentialOffer })).toEqual(
       'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fcredential-issuer.example.com%22%2C%22credential_configuration_ids%22%3A%5B%22UniversityDegreeCredential%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22eyJhbGciOiJSU0Et...FYUaBy%22%7D%7D%7D',
     )
+  })
+
+  it('create a v13 credential offer with grants', () => {
+    const credentialOffer = {
+      credential_issuer: 'https://credential-issuer.example.com',
+      credential_configuration_ids: ['UniversityDegreeCredential'],
+      grants: {
+        authorization_code: {
+          issuer_state: 'eyJhbGciOiJSU0Et...FYUaBy',
+        },
+      },
+    } satisfies CredentialOfferPayloadV1_0_13
+    expect(
+      createCredentialOfferObject(undefined, {
+        credentialOfferUri: 'https://test.com',
+        credentialOffer: {
+          credential_configuration_ids: ['one'],
+          credential_issuer: credentialOffer.credential_issuer,
+        },
+        grants: {
+          authorization_code: {
+            authorization_server: 'https://test.com',
+          },
+          [PRE_AUTH_GRANT_LITERAL]: {
+            authorization_server: 'https://test.com',
+          },
+        },
+      }),
+    ).toEqual({
+      credential_offer: {
+        credential_configuration_ids: ['one'],
+        credential_issuer: 'https://credential-issuer.example.com',
+        grants: {
+          authorization_code: {
+            authorization_server: 'https://test.com',
+            issuer_state: expect.any(String),
+          },
+          [PRE_AUTH_GRANT_LITERAL]: {
+            [PRE_AUTH_CODE_LITERAL]: expect.any(String),
+            authorization_server: 'https://test.com',
+          },
+        },
+      },
+      credential_offer_uri: 'https://test.com',
+    })
   })
 
   it('create an https link from credentialOffer object', () => {
@@ -47,7 +92,7 @@ describe('CredentialOfferUtils should', () => {
           issuer: 'test_issuer',
           credentials_supported: [],
         },
-        { credentialOffer, state: 'eyJhbGciOiJSU0Et...FYUaBy', scheme: 'https' },
+        { credentialOffer, scheme: 'https' },
       ),
     ).toEqual(
       `${credentialOffer.credential_issuer}?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Fcredential-issuer.example.com%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22jwt_vc_json%22%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22eyJhbGciOiJSU0Et...FYUaBy%22%7D%7D%7D`,
@@ -80,7 +125,7 @@ describe('CredentialOfferUtils should', () => {
           issuer: 'test_issuer',
           credentials_supported: [],
         },
-        { credentialOffer, state: 'eyJhbGciOiJSU0Et...FYUaBy', scheme: 'http' },
+        { credentialOffer, scheme: 'http' },
       ),
     ).toEqual(
       `${credentialOffer.credential_issuer}?credential_offer=%7B%22credential_issuer%22%3A%22http%3A%2F%2Fcredential-issuer.example.com%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22jwt_vc_json%22%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22eyJhbGciOiJSU0Et...FYUaBy%22%7D%7D%7D`,

--- a/packages/issuer/lib/__tests__/VcIssuer.spec.ts
+++ b/packages/issuer/lib/__tests__/VcIssuer.spec.ts
@@ -285,7 +285,7 @@ describe('VcIssuer', () => {
           credentialOfferUri: 'https://somehost.com/offer-id',
         })
         .then((response) => response.uri),
-    ).resolves.toEqual('http://issuer-example.com?credential_offer_uri=https://somehost.com/offer-id')
+    ).resolves.toEqual('http://issuer-example.com?credential_offer_uri=https%3A%2F%2Fsomehost.com%2Foffer-id')
   })
 
   // Of course this doesn't work. The state is part of the proof to begin with

--- a/packages/oid4vci-common/lib/types/Generic.types.ts
+++ b/packages/oid4vci-common/lib/types/Generic.types.ts
@@ -314,7 +314,7 @@ export interface IssuerCredentialSubject {
 
 export interface Grant {
   authorization_code?: GrantAuthorizationCode;
-  'urn:ietf:params:oauth:grant-type:pre-authorized_code'?: GrantUrnIetf;
+  [PRE_AUTH_GRANT_LITERAL]?: GrantUrnIetf;
 }
 
 export interface GrantAuthorizationCode {


### PR DESCRIPTION
Some improvements / cleanup to the credential offer creation process:
- Take the input  grants as leading, and only set default values if a required prop is not provided. Currently the grants objects are overwritten in some places, which means that a) you can't add custom properties and b) the `authorization_server` in e.g. the pre auth flow was removed when the offer was created
- do not put the whole credential offer uri in the `credential_offer_uri` param, this was leading to weird behaviour where sometimes the value would be the whole uri `openid-credential-offer://credential_offer_uri=<uri>` and sometimes just `<uri>`. So now the object just contains the uri that hosts the credential offer, not the uri that is scanned by the wallet (it's quite confusing that the credential offer uri can contain a `credential_offer_uri` param, so it was somtimes interchanged).
- Correctly encode the `credential_offer_uri` param (Fixes https://github.com/Sphereon-Opensource/OID4VC/issues/102)