### PR TITLE
fix: use error reason if provided

### DIFF
--- a/packages/siop-oid4vp/lib/authorization-response/PresentationExchange.ts
+++ b/packages/siop-oid4vp/lib/authorization-response/PresentationExchange.ts
@@ -393,12 +393,17 @@ export class PresentationExchange {
       // Verify the signature of all VPs
       await Promise.all(
         presentationsToVerify.map(async (presentation) => {
-          let verificationResult:PresentationVerificationResult
+          let verificationResult: PresentationVerificationResult
           try {
-            verificationResult=  await verifyPresentationCallback(presentation as W3CVerifiablePresentation, evaluationResults.value!)
-            
+            verificationResult = await verifyPresentationCallback(presentation as W3CVerifiablePresentation, evaluationResults.value!)
           } catch (error: unknown) {
             throw new Error(SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID)
+          }
+
+          if (!verificationResult.verified) {
+            throw new Error(
+              SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID + (verificationResult.reason ? `. ${verificationResult.reason}` : ''),
+            )
           }
         }),
       )

--- a/packages/siop-oid4vp/lib/authorization-response/PresentationExchange.ts
+++ b/packages/siop-oid4vp/lib/authorization-response/PresentationExchange.ts
@@ -30,6 +30,7 @@ import {
   PresentationDefinitionWithLocation,
   PresentationSignCallback,
   PresentationVerificationCallback,
+  PresentationVerificationResult,
 } from './types'
 
 export class PresentationExchange {
@@ -392,13 +393,10 @@ export class PresentationExchange {
       // Verify the signature of all VPs
       await Promise.all(
         presentationsToVerify.map(async (presentation) => {
+          let verificationResult:PresentationVerificationResult
           try {
-            const verificationResult = await verifyPresentationCallback(presentation as W3CVerifiablePresentation, evaluationResults.value!)
-            if (!verificationResult.verified) {
-              throw new Error(
-                SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID + (verificationResult.reason ? `. ${verificationResult.reason}` : ''),
-              )
-            }
+            verificationResult=  await verifyPresentationCallback(presentation as W3CVerifiablePresentation, evaluationResults.value!)
+            
           } catch (error: unknown) {
             throw new Error(SIOPErrors.VERIFIABLE_PRESENTATION_SIGNATURE_NOT_VALID)
           }


### PR DESCRIPTION
small improvement to show the error reason if returned by the method. It was swallowed because of the try catch